### PR TITLE
헤더 컴포넌트 생성

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,6 +36,8 @@
       "namedComponents": "arrow-function",
       "unnamedComponents": "arrow-function"
     }],
+    // defaultprops는 쓰지 않는다.
+    "react/require-default-props": "off",
 
     "@typescript-eslint/no-use-before-define": "off",
 

--- a/app/_common/components/DarkToggle.tsx
+++ b/app/_common/components/DarkToggle.tsx
@@ -6,7 +6,11 @@ import { useCallback, useEffect, useState } from "react";
 
 import { classNames } from "../utils/classNames";
 
-export const DarkToggle = () => {
+interface DarkToggleProps {
+  className?: string;
+}
+
+export const DarkToggle = ({ className = "" }: DarkToggleProps) => {
   const [mount, setMount] = useState<boolean>(false);
   const { theme, setTheme } = useTheme();
 
@@ -29,6 +33,7 @@ export const DarkToggle = () => {
         theme === "dark"
           ? "bg-[#202020] after:left-[36px] after:bg-[#454545]"
           : "bg-[#dedede] after:left-1 after:bg-[#efefef]",
+        className,
       )}
     >
       <MoonIcon className="absolute top-2 left-[40px] z-10 w-5 h-5" />

--- a/app/_common/components/Header.tsx
+++ b/app/_common/components/Header.tsx
@@ -39,7 +39,7 @@ export const Header = () => {
           </h1>
           <nav
             className={classNames(
-              "hidden",
+              "hidden text-[#454545]",
               "sm:flex-1 sm:flex sm:items-center sm:space-x-6",
             )}
           >
@@ -71,7 +71,7 @@ export const Header = () => {
       {!isClose && (
         <nav
           className={classNames(
-            "fixed z-40 w-full h-[calc(100%-64px)] top-16 bg-[#EFEFEF]",
+            "fixed z-40 w-full h-[calc(100%-64px)] top-16 bg-[#EFEFEF] text-[#454545]",
             "sm:hidden",
           )}
         >

--- a/app/_common/components/Header.tsx
+++ b/app/_common/components/Header.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { Bars3Icon, XMarkIcon } from "@heroicons/react/20/solid";
+import Link from "next/link";
+import { useState } from "react";
+
+import { classNames } from "../utils/classNames";
+import { DarkToggle } from "./DarkToggle";
+
+const path = [
+  {
+    name: "정리노트",
+    href: "/note",
+  },
+  {
+    name: "스니펫",
+    href: "/snippet",
+  },
+  {
+    name: "나의일기",
+    href: "/record",
+  },
+];
+
+export const Header = () => {
+  const [isClose, setIsClose] = useState(true);
+
+  return (
+    <>
+      <header className="fixed z-40 top-0 w-full h-16 border-b border-[#dedede] backdrop-blur-sm bg-[#EFEFEF] bg-opacity-90">
+        <div className="max-w-5xl w-full h-full m-auto px-6 flex items-center">
+          <h1
+            className={classNames(
+              "text-2xl font-bold text-[#121212 flex-1 tracking-wide",
+              "sm:flex-none sm:mr-12",
+            )}
+          >
+            DEVCO
+          </h1>
+          <nav
+            className={classNames(
+              "hidden",
+              "sm:flex-1 sm:flex sm:items-center sm:space-x-6",
+            )}
+          >
+            {path.map(({ name, href }) => (
+              <Link href={href} key={name}>
+                {name}
+              </Link>
+            ))}
+          </nav>
+          <DarkToggle className="hidden sm:block" />
+          <Bars3Icon
+            className={classNames(
+              "w-8 h-8 cursor-pointer",
+              !isClose && "hidden",
+              "sm:hidden",
+            )}
+            onClick={() => setIsClose((isClosed) => !isClosed)}
+          />
+          <XMarkIcon
+            className={classNames(
+              "w-8 h-8 cursor-pointer",
+              isClose && "hidden",
+              "sm:hidden",
+            )}
+            onClick={() => setIsClose((isClosed) => !isClosed)}
+          />
+        </div>
+      </header>
+      {!isClose && (
+        <nav
+          className={classNames(
+            "fixed z-40 w-full h-[calc(100%-64px)] top-16 bg-[#EFEFEF]",
+            "sm:hidden",
+          )}
+        >
+          <div className="flex flex-col items-start space-y-4 p-6">
+            {path.map(({ name, href }) => (
+              <Link href={href} key={name} className="text-lg">
+                {name}
+              </Link>
+            ))}
+          </div>
+          <div className="flex justify-center items-center space-x-4">
+            <DarkToggle />
+          </div>
+        </nav>
+      )}
+    </>
+  );
+};

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { Black_Han_Sans, Noto_Sans_KR } from "next/font/google";
 import localFont from "next/font/local";
 
+import { Header } from "./_common/components/Header";
 import { Providers } from "./_common/Providers";
 import { classNames } from "./_common/utils/classNames";
 
@@ -41,7 +42,10 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
           "font-noto",
         )}
       >
-        <Providers>{children}</Providers>
+        <Providers>
+          <Header />
+          <div className="pt-16">{children}</div>
+        </Providers>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,9 +4,9 @@ import { PropsWithChildren } from "react";
 
 const Page = () => {
   return (
-    <main className="py-12 sm:py-40 max-w-2xl m-auto px-4">
+    <main className="py-10 sm:py-14 max-w-2xl m-auto px-4">
       <section className="mt-3 mb-6">
-        <h1 className="font-blackHan text-3xl underline underline-offset-4">
+        <h1 className="font-blackHan text-[1.75rem] sm:text-3xl underline underline-offset-4">
           안녕하세요. 구교현입니다.
         </h1>
         <p className="pt-4 text-[#343434]">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,14 +2,9 @@ import { ChevronRightIcon } from "@heroicons/react/24/outline";
 import Link from "next/link";
 import { PropsWithChildren } from "react";
 
-import { DarkToggle } from "./_common/components/DarkToggle";
-
 const Page = () => {
   return (
-    <main className="py-12 sm:py-16 max-w-2xl m-auto px-4">
-      <div className="h-[36px] flex justify-end">
-        <DarkToggle />
-      </div>
+    <main className="py-12 sm:py-40 max-w-2xl m-auto px-4">
       <section className="mt-3 mb-6">
         <h1 className="font-blackHan text-3xl underline underline-offset-4">
           안녕하세요. 구교현입니다.


### PR DESCRIPTION
### 작업한 내용

* 원래는 해더를 넣지 않으려하다가 헤더가 없으면 생기는 수많은 불편한 사항들 때문에 헤더를 넣기로 결정했습니다. 
* 헤더 컴포넌트는 NextJS의 헤더에서 많은 부분을 참고했습니다. 

### 아쉬운 점 

* 모바일일때 다크모드 버튼을 어디에 두어야 좋을지 참 애매합니다.