### PR TITLE
초기 테마 system일때 대응

### DIFF
--- a/app/_common/components/DarkToggle.tsx
+++ b/app/_common/components/DarkToggle.tsx
@@ -14,10 +14,21 @@ export const DarkToggle = ({ className = "" }: DarkToggleProps) => {
   const [mount, setMount] = useState<boolean>(false);
   const { theme, setTheme } = useTheme();
 
-  const handleToggle = useCallback(
-    () => (theme === "light" ? setTheme("dark") : setTheme("light")),
-    [setTheme, theme],
-  );
+  const handleToggle = useCallback(() => {
+    if (theme === "system") {
+      if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+        setTheme("light");
+        return;
+      }
+      setTheme("dark");
+      return;
+    }
+    if (theme === "light") {
+      setTheme("dark");
+      return;
+    }
+    setTheme("light");
+  }, [setTheme, theme]);
 
   useEffect(() => setMount(true), [setMount]);
 
@@ -30,9 +41,8 @@ export const DarkToggle = ({ className = "" }: DarkToggleProps) => {
         "relative block w-[68px] h-[36px] rounded-full cursor-pointer shadow-[inset_0px_2px_4px_rgba(0,0,0,0.3),_inset_0px_2px_4px_rgba(255,255,255,0.2)]",
         "transition-colors after:transition-[left_colors] duration-200 after:duration-200",
         "after:absolute after:w-7 after:h-7 after:rounded-full after:top-1 after:left-1 after:shadow-[0px_2px_4px_rgba(0,0,0,0.2)]",
-        theme === "dark"
-          ? "bg-[#202020] after:left-[36px] after:bg-[#454545]"
-          : "bg-[#dedede] after:left-1 after:bg-[#efefef]",
+        "dark:bg-[#202020] dark:after:left-[36px] dark:after:bg-[#454545]",
+        "bg-[#dedede] after:left-1 after:bg-[#efefef]",
         className,
       )}
     >


### PR DESCRIPTION
### 진행한 일

맨 처음 LocalStorage에 테마 값이 설정되기 전에 화면에 진입하면 버튼 색깔이 화이트모드로 고정되는 버그가 있었습니다. 해당 버그는 맨 처음 진입시 system임을 고려하지 못해서 생긴 버그입니다. 맨 처음에 localStorage 값이 없을 때 system임을 인지하는 처리를 해서 해당 버그를 수정하였습니다.

### 사진
* 버그가 있는 사진
<img width="966" alt="스크린샷 2023-09-23 오후 6 20 28" src="https://github.com/rygus9/blog/assets/52780207/71899905-2e91-4ddd-bd4d-5467fccf5427">

* 수정한 버전
<img width="966" alt="스크린샷 2023-09-23 오후 6 21 06" src="https://github.com/rygus9/blog/assets/52780207/6f72cd92-55c7-42f3-9f06-f98ada409bf8">
