### PR TITLE
main 페이지에서 snippet 제거

### DIFF
--- a/app/_common/components/Header.tsx
+++ b/app/_common/components/Header.tsx
@@ -15,11 +15,6 @@ const path = [
     section: "note",
   },
   {
-    name: "스니펫",
-    href: "/snippet",
-    section: "snippet",
-  },
-  {
     name: "나의일기",
     href: "/record",
     section: "record",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@ import { ChevronRightIcon } from "@heroicons/react/24/outline";
 import Link from "next/link";
 import { PropsWithChildren } from "react";
 
-import { notes, snippets } from "./_common/mock";
+import { notes } from "./_common/mock";
 
 const Page = () => {
   return (
@@ -51,17 +51,6 @@ const Page = () => {
           ))}
         </ul>
         <MoreLink href="/note" />
-      </section>
-      <hr className="border-back-em my-8" />
-      <section>
-        <Category href="/snippet">스니펫</Category>
-
-        <ul className="mt-2 flex flex-wrap items-start justify-between">
-          {snippets.map((props) => (
-            <ContentItem type="snippet" {...props} />
-          ))}
-        </ul>
-        <MoreLink href="/snippet" />
       </section>
     </main>
   );


### PR DESCRIPTION
### 제거하는 이유

1. 정리노트와 기능이 거의 같음.
짧은 글을 빠르게 보려고 따로 분리했으나 결국에는 정리 노트와 기능이 같다. 괜히 관리할 부분을 늘리는것 같은 느낌이 들어서 하나로 통합함.

2. 다르게 할 부분을 못찾음
위에랑 동일한 맥락으로 스니펫만의 포인트를 못찾았음. 그냥 합치는게 나은 것 같음.