### PR TITLE
노트 리스트 카드 뷰 변경

### DIFF
--- a/app/_common/components/BlogListCard.tsx
+++ b/app/_common/components/BlogListCard.tsx
@@ -1,0 +1,40 @@
+import { CalendarIcon } from "@heroicons/react/20/solid";
+import Link from "next/link";
+
+interface BlogListCardProps {
+  title: string;
+  titleSlug: string;
+  intro: string;
+  createdAt: string;
+  category: string;
+  categorySlug: string;
+}
+
+export const BlogListCard = ({
+  category,
+  categorySlug,
+  createdAt,
+  intro,
+  title,
+  titleSlug,
+}: BlogListCardProps) => {
+  return (
+    <article>
+      <p className="w-fit py-1 px-2 rounded-sm bg-back-em text-txt-300 text-sm cursor-pointer">
+        <Link href={`/note?category=${categorySlug}`}>{category}</Link>
+      </p>
+      <h3 className="text-lg text-txt-700 mt-1">
+        <Link href={`/note/${titleSlug}`} className="align-middle mr-2">
+          {title}
+        </Link>
+      </h3>
+      <p className="text-txt-300 mt-1">{intro}</p>
+      <section className="mt-2">
+        <span className="inline-flex flex-wrap gap-1 items-center text-sm text-txt-300 align-middle">
+          <CalendarIcon className="w-4 h-4" />
+          <span className="font-arita">{createdAt}</span>
+        </span>
+      </section>
+    </article>
+  );
+};

--- a/app/_common/components/NoteListCard.tsx
+++ b/app/_common/components/NoteListCard.tsx
@@ -10,7 +10,7 @@ interface BlogListCardProps {
   categorySlug: string;
 }
 
-export const BlogListCard = ({
+export const NoteListCard = ({
   category,
   categorySlug,
   createdAt,

--- a/app/_common/mock.ts
+++ b/app/_common/mock.ts
@@ -1,53 +1,34 @@
 export const notes = [
   {
+    categorySlug: "blog",
+    category: "블로그 개발기",
+    titleSlug: "notion-api",
+    title: "Notion API 연동하기",
+    intro: "Notion API를 사용해서 블로그를 개발하는 방법을 알려드립니다.",
+    createdAt: "2022-10-20",
+  },
+  {
     categorySlug: "2023",
     category: "2023 모음",
-    titleSlug: "react-13",
-    title: "React 13 분석하기",
+    titleSlug: "frontend-build",
+    title: "프론트엔드 개발 환경",
+    intro: "프론트엔드 개발 환경에 대한 전반적인 내용을 정리했습니다.",
+    createdAt: "2023-10-20",
   },
   {
     categorySlug: "blog",
     category: "블로그 개발기",
     titleSlug: "notion-api",
-    title: "Notion API 연동하기",
+    title: "Notion API 연동하기 조금 많이 긴 제목이라면 어떻게할까요?",
+    intro: "Notion API를 사용해서 블로그를 개발하는 방법을 알려드립니다.",
+    createdAt: "2022-10-20",
   },
   {
-    categorySlug: "blog",
-    category: "블로그 개발기",
-    titleSlug: "blog-design-structure",
-    title: "디자인 구성, 블로그 구조 설계",
-  },
-  {
-    categorySlug: "blog",
-    category: "블로그 개발기",
-    titleSlug: "next-13-app",
-    title: "NextJS 13 app 디렉토리 도입하기",
-  },
-];
-
-export const snippets = [
-  {
-    categorySlug: "js",
-    category: "JS",
-    titleSlug: "json",
-    title: "JSON 변환",
-  },
-  {
-    categorySlug: "js",
-    category: "JS",
-    titleSlug: "json",
-    title: "유용한 정규식 모음",
-  },
-  {
-    categorySlug: "css",
-    category: "CSS",
-    titleSlug: "safe-area",
-    title: "safe-area 대응",
-  },
-  {
-    categorySlug: "js",
-    category: "CSS",
-    titleSlug: "center-align",
-    title: "요소 중앙 정렬",
+    categorySlug: "2023",
+    category: "2023 모음",
+    titleSlug: "frontend-build",
+    title: "프론트엔드 개발 환경",
+    intro: "프론트엔드 개발 환경에 대한 전반적인 내용을 정리했습니다.",
+    createdAt: "2023-10-20",
   },
 ];

--- a/app/note/_common/mock.ts
+++ b/app/note/_common/mock.ts
@@ -21,38 +21,34 @@ export const categorys = [
   },
 ];
 
-export const posts = [
+export const notes = [
   {
+    categorySlug: "blog",
+    category: "블로그 개발기",
     titleSlug: "notion-api",
     title: "Notion API 연동하기",
     intro: "Notion API를 사용해서 블로그를 개발하는 방법을 알려드립니다.",
     createdAt: "2022-10-20",
   },
   {
+    categorySlug: "2023",
+    category: "2023 모음",
     titleSlug: "frontend-build",
     title: "프론트엔드 개발 환경",
     intro: "프론트엔드 개발 환경에 대한 전반적인 내용을 정리했습니다.",
     createdAt: "2023-10-20",
   },
   {
+    categorySlug: "blog",
+    category: "블로그 개발기",
     titleSlug: "notion-api",
-    title: "Notion API 연동하기",
+    title: "Notion API 연동하기 조금 많이 긴 제목이라면 어떻게할까요?",
     intro: "Notion API를 사용해서 블로그를 개발하는 방법을 알려드립니다.",
     createdAt: "2022-10-20",
   },
   {
-    titleSlug: "frontend-build",
-    title: "프론트엔드 개발 환경",
-    intro: "프론트엔드 개발 환경에 대한 전반적인 내용을 정리했습니다.",
-    createdAt: "2023-10-20",
-  },
-  {
-    titleSlug: "notion-api",
-    title: "Notion API 연동하기",
-    intro: "Notion API를 사용해서 블로그를 개발하는 방법을 알려드립니다.",
-    createdAt: "2022-10-20",
-  },
-  {
+    categorySlug: "2023",
+    category: "2023 모음",
     titleSlug: "frontend-build",
     title: "프론트엔드 개발 환경",
     intro: "프론트엔드 개발 환경에 대한 전반적인 내용을 정리했습니다.",

--- a/app/note/page.tsx
+++ b/app/note/page.tsx
@@ -1,8 +1,9 @@
-import { ArrowUturnLeftIcon, CalendarIcon } from "@heroicons/react/20/solid";
+import { ArrowUturnLeftIcon } from "@heroicons/react/20/solid";
 import Link from "next/link";
 
+import { BlogListCard } from "../_common/components/BlogListCard";
 import { classNames } from "../_common/utils/classNames";
-import { categorys, posts } from "./_common/mock";
+import { categorys, notes } from "./_common/mock";
 
 interface SearchParams {
   category?: string;
@@ -75,19 +76,8 @@ const Page = ({
           </ul>
           <hr className="border-back-em my-8 lg:hidden" />
           <ul className="space-y-10">
-            {posts.map(({ title, titleSlug, intro, createdAt }) => (
-              <article>
-                <h3 className="text-lg text-txt-700">
-                  <Link href={`/note/${titleSlug}`} className="align-middle">
-                    {title}
-                  </Link>
-                  <span className="inline-flex ml-2 gap-1 items-center text-sm text-txt-300 align-middle">
-                    <CalendarIcon className="w-4 h-4" />
-                    <span className="font-arita">{createdAt}</span>
-                  </span>
-                </h3>
-                <p className="text-txt-300 mt-1">{intro}</p>
-              </article>
+            {notes.map((props) => (
+              <BlogListCard {...props} />
             ))}
           </ul>
         </section>

--- a/app/note/page.tsx
+++ b/app/note/page.tsx
@@ -1,7 +1,7 @@
 import { ArrowUturnLeftIcon } from "@heroicons/react/20/solid";
 import Link from "next/link";
 
-import { BlogListCard } from "../_common/components/BlogListCard";
+import { NoteListCard } from "../_common/components/NoteListCard";
 import { classNames } from "../_common/utils/classNames";
 import { categorys, notes } from "./_common/mock";
 
@@ -77,7 +77,7 @@ const Page = ({
           <hr className="border-back-em my-8 lg:hidden" />
           <ul className="space-y-10">
             {notes.map((props) => (
-              <BlogListCard {...props} />
+              <NoteListCard {...props} />
             ))}
           </ul>
         </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@ import { ChevronRightIcon } from "@heroicons/react/24/outline";
 import Link from "next/link";
 import { PropsWithChildren } from "react";
 
-import { BlogListCard } from "./_common/components/BlogListCard";
+import { NoteListCard } from "./_common/components/NoteListCard";
 import { notes } from "./_common/mock";
 
 const Page = () => {
@@ -48,7 +48,7 @@ const Page = () => {
         <Category href="/note">정리 노트</Category>
         <ul className="space-y-8 mt-6 mb-4">
           {notes.map((props) => (
-            <BlogListCard {...props} />
+            <NoteListCard {...props} />
           ))}
         </ul>
         <MoreLink href="/note" />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import { ChevronRightIcon } from "@heroicons/react/24/outline";
 import Link from "next/link";
 import { PropsWithChildren } from "react";
 
+import { BlogListCard } from "./_common/components/BlogListCard";
 import { notes } from "./_common/mock";
 
 const Page = () => {
@@ -45,9 +46,9 @@ const Page = () => {
       <hr className="border-back-em my-8" />
       <section>
         <Category href="/note">정리 노트</Category>
-        <ul className="mt-2 flex flex-wrap items-start justify-between">
+        <ul className="space-y-8 mt-6 mb-4">
           {notes.map((props) => (
-            <ContentItem type="note" {...props} />
+            <BlogListCard {...props} />
           ))}
         </ul>
         <MoreLink href="/note" />
@@ -55,29 +56,6 @@ const Page = () => {
     </main>
   );
 };
-
-const ContentItem = ({
-  categorySlug,
-  category,
-  titleSlug,
-  title,
-  type,
-}: {
-  categorySlug: string;
-  category: string;
-  titleSlug: string;
-  title: string;
-  type: "note" | "snippet";
-}) => (
-  <li className="w-[48%] py-4 space-y-2">
-    <p className="w-fit py-1 px-2 rounded-sm bg-back-em text-txt-300 text-sm cursor-pointer">
-      <Link href={`/${type}?category=${categorySlug}`}>{category}</Link>
-    </p>
-    <h3 className="cursor-pointer w-fit">
-      <Link href={`/${type}/${titleSlug}`}>{title}</Link>
-    </h3>
-  </li>
-);
 
 const Category = ({ href, children }: PropsWithChildren<{ href: string }>) => (
   <h2 className="text-xl text-txt-700 font-arita font-bold">


### PR DESCRIPTION
### 진행한 일

- [x] 노트 리스트 카드 컴포넌트 생성
- [x] 해당 컴포넌트 적용

### 화면
 
<img width="675" alt="스크린샷 2023-10-02 오전 10 38 18" src="https://github.com/rygus9/blog/assets/52780207/1c9a92f1-800a-478d-875e-66b15d4d0ce1">

### 고찰

원래는 simple is the best를 추구하려 했으나 나중에 벡엔드 연동해서 댓글 개수와 좋아요 같은 기능을 추가할 것 같기 때문에 다소 복잡해지더라도 이런 저런 기능이 추가될 수 있도록 개발하였다.
