### PR TITLE
import/extensions 룰 수정

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,9 @@
     "import/prefer-default-export": "off",
     "import/no-default-export": "error",
 
+    // 모듈 경로가 @app으로 시작하는 경우 에러. extension은 그냥 안쓰니 이를 수정함.
+    "import/extensions": "never",
+
     "react/jsx-props-no-spreading": "off",
     "react/react-in-jsx-scope": "off",
     // aribnb의 느슨한 self-closing-comp 룰 강화


### PR DESCRIPTION
"@app/...." 처럼 alias path로 모듈 경로를 표시하는 경우 뒤에 확장자 유무와 상관없이 해당 린트 룰 에러가 발생 -> 이를 수정하기 위해 진행함.