### PR TITLE
log 관련 함수 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ next-env.d.ts
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versionss
+
+# log or temp file
+temp

--- a/common/utils/logger.ts
+++ b/common/utils/logger.ts
@@ -4,8 +4,13 @@ import { resolve } from "path";
 import { inspect } from "util";
 
 export const log = (obj: any) => {
+  if (typeof window === "undefined") {
+    // eslint-disable-next-line no-console
+    console.log(inspect(obj, { depth: null, colors: true }));
+    return;
+  }
   // eslint-disable-next-line no-console
-  console.log(inspect(obj, { depth: null, colors: true }));
+  console.log(obj);
 };
 
 export const saveLog = ({

--- a/common/utils/logger.ts
+++ b/common/utils/logger.ts
@@ -1,0 +1,29 @@
+import { existsSync, mkdirSync } from "fs";
+import { writeFile } from "fs/promises";
+import { resolve } from "path";
+import { inspect } from "util";
+
+export const log = (obj: any) => {
+  // eslint-disable-next-line no-console
+  console.log(inspect(obj, { depth: null, colors: true }));
+};
+
+export const saveLog = ({
+  content,
+  filename,
+}: {
+  content: any;
+  filename: string;
+}) => {
+  const ext = "json";
+  const tempDirectoryPath = resolve(".", "temp");
+
+  if (!existsSync(tempDirectoryPath)) {
+    mkdirSync(tempDirectoryPath);
+  }
+
+  writeFile(
+    resolve(tempDirectoryPath, `${filename}.${ext}`),
+    JSON.stringify(content),
+  );
+};

--- a/common/utils/logger.ts
+++ b/common/utils/logger.ts
@@ -13,13 +13,8 @@ export const log = (obj: any) => {
   console.log(obj);
 };
 
-export const saveLog = ({
-  content,
-  filename,
-}: {
-  content: any;
-  filename: string;
-}) => {
+// !! For Debug
+export const saveObj = ({ obj, filename }: { obj: any; filename: string }) => {
   const ext = "json";
   const tempDirectoryPath = resolve(".", "temp");
 
@@ -29,6 +24,6 @@ export const saveLog = ({
 
   writeFile(
     resolve(tempDirectoryPath, `${filename}.${ext}`),
-    JSON.stringify(content),
+    JSON.stringify(obj),
   );
 };


### PR DESCRIPTION
### 한 일

- [x] util.inspect를 활용하는 log 함수 작성
- [x] obj를 파일로 저장하는 saveObj 함수 작성

### 만들게된 이유
* saveObj의 경우, notion API가 워낙 내가 잘 모르는 라이브러리다보니 res 값을 분석해야하는 경우가 많았는데 터미널로만 확인하기 너무 힘들었음.
* log의 경우, node에서는 object를 너무 보기 어렵게 해놔서 inspect 쓰는 버전으로 따로 만들었음.

### 고민 내용
* log는 브라우저환경에선 console.log로 돌아가게 해두어서 괜찮지만 saveObj은... 인터페이스 filename이 있으니 예상을 하지 않을까 싶다.
* log 파일에 담을까 하다가 나중에 사진이나 이런 것도 테스트용으로 넣을 것 같고 그래서 temp로 만들었다.