### PR TITLE
리스트도 출력가능하도록 BlocksRenderer 변경

### DIFF
--- a/notion/component/BlockRenderer.tsx
+++ b/notion/component/BlockRenderer.tsx
@@ -1,8 +1,23 @@
-import { BlockObjectResponse } from "@notionhq/client/build/src/api-endpoints";
+import {
+  BlockObjectResponse,
+  BulletedListItemBlockObjectResponse,
+  NumberedListItemBlockObjectResponse,
+} from "@notionhq/client/build/src/api-endpoints";
 
 import { RichText } from "./RichText";
 
-export const BlockRenderer = ({ block }: { block: BlockObjectResponse }) => {
+export type BlockObject =
+  | BlockObjectResponse
+  | {
+      type: "bulleted_list";
+      bulleted_list: BulletedListItemBlockObjectResponse[];
+    }
+  | {
+      type: "numbered_list";
+      numbered_list: NumberedListItemBlockObjectResponse[];
+    };
+
+export const BlockRenderer = ({ block }: { block: BlockObject }) => {
   const { type } = block;
 
   switch (type) {
@@ -36,6 +51,35 @@ export const BlockRenderer = ({ block }: { block: BlockObjectResponse }) => {
           <RichText texts={block.quote.rich_text} />
         </div>
       );
+    case "bulleted_list":
+      return (
+        <ul className="my-6 list-disc">
+          {block.bulleted_list.map((bulletedListItem) => (
+            <BlockRenderer block={bulletedListItem} key={bulletedListItem.id} />
+          ))}
+        </ul>
+      );
+    case "numbered_list":
+      return (
+        <ol className="my-6 list-decimal">
+          {block.numbered_list.map((numberedListItem) => (
+            <BlockRenderer block={numberedListItem} key={numberedListItem.id} />
+          ))}
+        </ol>
+      );
+    case "bulleted_list_item":
+      return (
+        <li className="my-3 ml-4">
+          <RichText texts={block.bulleted_list_item.rich_text} />
+        </li>
+      );
+    case "numbered_list_item":
+      return (
+        <li className="my-3 ml-4">
+          <RichText texts={block.numbered_list_item.rich_text} />
+        </li>
+      );
+
     default:
       return <p />;
   }

--- a/notion/component/BlocksRenderer.tsx
+++ b/notion/component/BlocksRenderer.tsx
@@ -4,25 +4,63 @@ import {
 } from "@notionhq/client/build/src/api-endpoints";
 
 import { notion } from "..";
-import { BlockRenderer } from "./BlockRenderer";
+import { BlockObject, BlockRenderer } from "./BlockRenderer";
 
 export const BlocksRenderer = async ({ block_id }: { block_id: string }) => {
   let next_cursor;
-  const blocks: (BlockObjectResponse | PartialBlockObjectResponse)[] = [];
+  const blocksResponse: (BlockObjectResponse | PartialBlockObjectResponse)[] =
+    [];
   do {
     // eslint-disable-next-line no-await-in-loop
     const result = await notion.blocks.children.list({
       block_id,
       start_cursor: next_cursor ?? undefined,
     });
-    blocks.push(...result.results);
+    blocksResponse.push(...result.results);
   } while (next_cursor);
+
+  const blocks = generateListBlock(blocksResponse as BlockObjectResponse[]);
 
   return (
     <>
       {blocks.map((block) => (
-        <BlockRenderer block={block as BlockObjectResponse} />
+        <BlockRenderer block={block} />
       ))}
     </>
   );
+};
+
+const generateListBlock = (blocks: BlockObjectResponse[]) => {
+  return blocks.reduce<BlockObject[]>((acc, cur) => {
+    const lastAcc = acc[acc.length - 1];
+
+    if (cur.type === "bulleted_list_item") {
+      if (lastAcc?.type === "bulleted_list") {
+        lastAcc.bulleted_list.push(cur);
+        return acc;
+      }
+      const newBlock: BlockObject = {
+        type: "bulleted_list",
+        bulleted_list: [cur],
+      };
+      acc.push(newBlock);
+      return acc;
+    }
+
+    if (cur.type === "numbered_list_item") {
+      if (lastAcc?.type === "numbered_list") {
+        lastAcc.numbered_list.push(cur);
+        return acc;
+      }
+      const newBlock: BlockObject = {
+        type: "numbered_list",
+        numbered_list: [cur],
+      };
+      acc.push(newBlock);
+      return acc;
+    }
+
+    acc.push(cur);
+    return acc;
+  }, []);
 };


### PR DESCRIPTION
### 진행한 일 

- [x] bulleted_list 타입과 numbered_list 타입의 오브젝트 안에 아이템이 들어가도록 수정
- [x] 해당 오브젝트롤 출력함.

### 결과 사진
<img width="672" alt="스크린샷 2023-10-27 오후 6 20 32" src="https://github.com/rygus9/blog/assets/52780207/5bfc6180-c31b-41b6-baca-e56ac81d5251">

<img width="672" alt="스크린샷 2023-10-27 오후 6 20 49" src="https://github.com/rygus9/blog/assets/52780207/e66912f8-d34b-4852-851a-0d9590aec32f">

### 주의사항
children 처리는 나중에 한꺼번에 합니다!
