### PR TITLE
feat: 색상 추가 및 이름 변경

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,6 +6,7 @@
   :root { 
     --color-bg: 239, 239, 239;
     --color-bg-em: 222, 222, 222;
+    --color-border: 204, 204, 204;
     --color-text-week: 103, 103, 103;
     --color-text: 52, 52, 52;
     --color-text-em: 18, 18, 18;
@@ -14,6 +15,7 @@
   :root[class~="dark"] {
     --color-bg: 18, 18, 18;
     --color-bg-em: 52, 52, 52;
+    --color-border: 80, 80, 80;
     --color-text-week: 171, 171, 171;
     --color-text: 205, 205, 205;
     --color-text-em: 239, 239, 239;

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,25 +4,25 @@
 
 @layer base {
   :root { 
-    --color-bg: 239, 239, 239;
-    --color-bg-em: 222, 222, 222;
-    --color-border: 204, 204, 204;
-    --color-text-week: 103, 103, 103;
-    --color-text: 52, 52, 52;
-    --color-text-em: 18, 18, 18;
+    --color-contrast-100: 243, 243, 243;
+    --color-contrast-200: 222, 222, 222;
+    --color-contrast-300: 204, 204, 204;
+    --color-contrast-500: 103, 103, 103;
+    --color-contrast-600: 52, 52, 52;
+    --color-contrast-700: 18, 18, 18;
   }
 
   :root[class~="dark"] {
-    --color-bg: 18, 18, 18;
-    --color-bg-em: 52, 52, 52;
-    --color-border: 80, 80, 80;
-    --color-text-week: 171, 171, 171;
-    --color-text: 205, 205, 205;
-    --color-text-em: 239, 239, 239;
+    --color-contrast-100: 18, 18, 18;
+    --color-contrast-200: 52, 52, 52;
+    --color-contrast-300: 80, 80, 80;
+    --color-contrast-500: 171, 171, 171;
+    --color-contrast-600: 205, 205, 205;
+    --color-contrast-700: 239, 239, 239;
   }
 
   body {
-    background: rgb(var(--color-bg));
-    color: rgb(var(--color-text));
+    background: rgb(var(--color-contrast-100));
+    color: rgb(var(--color-contrast-600));
   }
 }

--- a/app/note/page.tsx
+++ b/app/note/page.tsx
@@ -23,7 +23,7 @@ const Page = async () => {
       <Divider />
       <section className="relative">
         <CategoryNav categorys={categorys} />
-        <hr className="border-back-em my-8 lg:hidden" />
+        <hr className="border-contrast-200 my-8 lg:hidden" />
         <NoteList notes={notes} />
       </section>
     </main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,7 +13,7 @@ const SectionTitle = ({
   href,
   children,
 }: PropsWithChildren<{ href: string }>) => (
-  <h2 className="text-lg text-txt-700 font-arita font-bold">
+  <h2 className="text-lg text-contrast-700 font-arita font-bold">
     <Link href={href} className="flex items-center justify-start">
       {children} <ChevronRightIcon className="w-5 h-5 ml-1 stroke-2" />
     </Link>
@@ -22,7 +22,7 @@ const SectionTitle = ({
 
 const MoreLink = ({ href }: { href: string }) => (
   <Link
-    className="inline-block mt-2 text-sm text-txt-300 font-arita"
+    className="inline-block mt-2 text-sm text-contrast-500 font-arita"
     href={href}
   >
     더보기...
@@ -63,7 +63,7 @@ const Page = async () => {
       <section>
         <SectionTitle href="/record">나의 일기</SectionTitle>
         <div className="my-3">
-          <span className="inline-flex gap-1 items-center text-txt-300 align-middle">
+          <span className="inline-flex gap-1 items-center text-contrast-500 align-middle">
             <CalendarIcon className="w-4 h-4" />
             <span className="font-arita">{created}</span>
           </span>

--- a/app/record/page.tsx
+++ b/app/record/page.tsx
@@ -14,7 +14,7 @@ const Page = async () => {
       </Title>
       <Divider />
 
-      <div className="divide-y divide-back-em">
+      <div className="divide-y divide-contrast-200">
         {records.map((props) => (
           <RecordCard {...props} key={props.id} />
         ))}

--- a/component/Header.tsx
+++ b/component/Header.tsx
@@ -33,7 +33,7 @@ export const Header = () => {
 
   return (
     <>
-      <header className="fixed z-40 top-0 w-full h-16 border-b border-back-em backdrop-blur-sm bg-back bg-opacity-90">
+      <header className="fixed z-40 top-0 w-full h-16 border-b border-border backdrop-blur-sm bg-back bg-opacity-90">
         <div className="max-w-5xl w-full h-full m-auto px-6 flex items-center">
           <h1
             className={classNames(

--- a/component/Header.tsx
+++ b/component/Header.tsx
@@ -33,11 +33,11 @@ export const Header = () => {
 
   return (
     <>
-      <header className="fixed z-40 top-0 w-full h-16 border-b border-border backdrop-blur-sm bg-back bg-opacity-90">
+      <header className="fixed z-40 top-0 w-full h-16 border-b border-contrast-300 backdrop-blur-sm bg-contrast-100 bg-opacity-90">
         <div className="max-w-5xl w-full h-full m-auto px-6 flex items-center">
           <h1
             className={classNames(
-              "text-2xl font-bold text-txt-700 flex-1 tracking-wide",
+              "text-2xl font-bold text-contrast-700 flex-1 tracking-wide",
               "sm:flex-none sm:mr-12",
             )}
           >
@@ -47,7 +47,7 @@ export const Header = () => {
           </h1>
           <div
             className={classNames(
-              "hidden text-txt-300",
+              "hidden text-contrast-500",
               "sm:flex-1 sm:flex sm:items-center sm:space-x-6",
             )}
           >
@@ -56,7 +56,7 @@ export const Header = () => {
                 href={href}
                 key={name}
                 className={classNames(
-                  nowSection === section && "text-txt-500 font-semibold",
+                  nowSection === section && "text-contrast-600 font-semibold",
                 )}
               >
                 {name}
@@ -85,7 +85,7 @@ export const Header = () => {
       {!isClose && (
         <div
           className={classNames(
-            "fixed z-40 w-full h-[calc(100%-64px)] top-16 bg-back text-txt-300",
+            "fixed z-40 w-full h-[calc(100%-64px)] top-16 bg-contrast-100 text-contrast-500",
             "sm:hidden",
           )}
         >
@@ -96,7 +96,7 @@ export const Header = () => {
                 key={name}
                 className={classNames(
                   "text-lg",
-                  nowSection === section && "text-txt-500 font-semibold",
+                  nowSection === section && "text-contrast-600 font-semibold",
                 )}
                 onClick={onClose}
               >

--- a/component/common/Divider.tsx
+++ b/component/common/Divider.tsx
@@ -1,1 +1,1 @@
-export const Divider = () => <hr className="border-back-em my-8" />;
+export const Divider = () => <hr className="border-border my-8" />;

--- a/component/common/Divider.tsx
+++ b/component/common/Divider.tsx
@@ -1,1 +1,1 @@
-export const Divider = () => <hr className="border-border my-8" />;
+export const Divider = () => <hr className="border-contrast-300 my-8" />;

--- a/component/common/Title.tsx
+++ b/component/common/Title.tsx
@@ -26,7 +26,7 @@ export const Title = ({
           >
             <Link
               href="/"
-              className="inline-flex items-center space-x-2 text-txt-300 hover:text-txt-700"
+              className="inline-flex items-center space-x-2 text-contrast-500 hover:text-contrast-700"
             >
               <ArrowUturnLeftIcon className="w-4 h-4" />
               <span> 홈으로</span>

--- a/component/note/CategoryNav.tsx
+++ b/component/note/CategoryNav.tsx
@@ -16,14 +16,14 @@ export const CategoryNav = ({ categorys }: CategoryNavProps) => {
   return (
     <ul
       className={classNames(
-        "flex items-center gap-4 gap-y-2 text-txt-300 mb-6 flex-wrap text-base",
+        "flex items-center gap-4 gap-y-2 text-contrast-500 mb-6 flex-wrap text-base",
         "lg:flex-col lg:items-start lg:gap-y-4 lg:absolute lg:-left-40 lg:top-1 lg:w-40 lg:h-fit",
       )}
     >
       <li className={classNames(!nowCategory && "-order-1")}>
         <Link
           href="/note"
-          className={classNames(!nowCategory && "text-txt-700 text-lg")}
+          className={classNames(!nowCategory && "text-contrast-700 text-lg")}
         >
           전체 보기
         </Link>
@@ -36,7 +36,7 @@ export const CategoryNav = ({ categorys }: CategoryNavProps) => {
           <Link
             href={`/note?category=${category}`}
             className={classNames(
-              nowCategory === category && "text-txt-700 text-lg",
+              nowCategory === category && "text-contrast-700 text-lg",
             )}
           >
             {category}

--- a/component/note/NoteListCard.tsx
+++ b/component/note/NoteListCard.tsx
@@ -14,17 +14,17 @@ export const NoteListCard = ({
 }: NoteListCardProps) => {
   return (
     <article>
-      <p className="w-fit py-1 px-2 rounded-sm bg-back-em text-txt-300 text-sm cursor-pointer">
+      <p className="w-fit py-1 px-2 rounded-sm bg-contrast-100-em text-contrast-500 text-sm cursor-pointer">
         <Link href={`/note?category=${category}`}>{category}</Link>
       </p>
-      <h3 className="text-lg text-txt-700 mt-1">
+      <h3 className="text-lg text-contrast-700 mt-1">
         <Link href={`/note/${slug}`} className="align-middle mr-2">
           {title}
         </Link>
       </h3>
-      <p className="text-txt-300 mt-1">{short}</p>
+      <p className="text-contrast-500 mt-1">{short}</p>
       <section className="mt-2">
-        <span className="inline-flex flex-wrap gap-1 items-center text-sm text-txt-300 align-middle">
+        <span className="inline-flex flex-wrap gap-1 items-center text-sm text-contrast-500 align-middle">
           <CalendarIcon className="w-4 h-4" />
           <span className="font-arita">{created}</span>
         </span>

--- a/component/record/RecordCard.tsx
+++ b/component/record/RecordCard.tsx
@@ -8,20 +8,20 @@ interface RecordCardProps extends Omit<RecordMeta, "id"> {}
 export const RecordCard = ({ content, created, title }: RecordCardProps) => (
   <article className="py-8 first:pt-0">
     <h2
-      className="text-[22px] text-txt-500 font-semibold scroll-mt-20"
+      className="text-[22px] text-contrast-600 font-semibold scroll-mt-20"
       id={created}
     >
       <a
         href={`#${created}`}
         className={classNames(
           "flex items-center justify-start gap-1",
-          "hover:text-txt-300",
+          "hover:text-contrast-500",
         )}
       >
-        {title} <LinkIcon className="w-5 h-5 text-txt-300" />
+        {title} <LinkIcon className="w-5 h-5 text-contrast-500" />
       </a>
     </h2>
-    <span className="inline-flex gap-1 items-center text-sm text-txt-300 align-middle mt-1">
+    <span className="inline-flex gap-1 items-center text-sm text-contrast-500 align-middle mt-1">
       <CalendarIcon className="w-4 h-4" />
       <span className="font-arita">{created}</span>
     </span>

--- a/notion/component/BlockRenderer.tsx
+++ b/notion/component/BlockRenderer.tsx
@@ -103,7 +103,7 @@ export const BlockRenderer = async ({ block }: { block: BlockObject }) => {
       })) as TableRowBlockObjectResponse[];
 
       return (
-        <table className="my-6 table-auto border-collapse border border-back-em">
+        <table className="my-6 table-auto border-collapse border border-border">
           {childrenBlock.map((tableRowBlock, row_idx) => (
             <tr>
               {tableRowBlock.table_row.cells.map((col, col_idx) =>
@@ -112,11 +112,11 @@ export const BlockRenderer = async ({ block }: { block: BlockObject }) => {
                  */
                 (row_idx === 0 && has_column_header) ||
                 (col_idx === 0 && has_row_header) ? (
-                  <th className="border border-back-em p-2 pr-6 bg-back-em text-left">
+                  <th className="border border-border p-2 pr-6 bg-back-em text-left">
                     <RichText texts={col} />
                   </th>
                 ) : (
-                  <td className="border border-back-em p-2 pr-6">
+                  <td className="border border-border p-2 pr-6">
                     <RichText texts={col} />
                   </td>
                 ),

--- a/notion/component/BlockRenderer.tsx
+++ b/notion/component/BlockRenderer.tsx
@@ -32,25 +32,25 @@ export const BlockRenderer = async ({ block }: { block: BlockObject }) => {
       );
     case "heading_1":
       return (
-        <h1 className="mt-14 mb-6 text-txt-700">
+        <h1 className="mt-14 mb-6 text-contrast-700">
           <RichText texts={block.heading_1.rich_text} />
         </h1>
       );
     case "heading_2":
       return (
-        <h2 className="mt-10 mb-6 text-2xl font-semibold text-txt-700">
+        <h2 className="mt-10 mb-6 text-2xl font-semibold text-contrast-700">
           <RichText texts={block.heading_2.rich_text} />
         </h2>
       );
     case "heading_3":
       return (
-        <h3 className="mt-8 mb-6 text-xl font-semibold text-txt-700">
+        <h3 className="mt-8 mb-6 text-xl font-semibold text-contrast-700">
           <RichText texts={block.heading_3.rich_text} />
         </h3>
       );
     case "quote":
       return (
-        <div className="border-l-4 border-txt-500 px-4 py-2 bg-back-em bg-opacity-60 leading-7">
+        <div className="border-l-4 border-contrast-600 px-4 py-2 bg-contrast-100-em bg-opacity-60 leading-7">
           <RichText texts={block.quote.rich_text} />
         </div>
       );
@@ -103,7 +103,7 @@ export const BlockRenderer = async ({ block }: { block: BlockObject }) => {
       })) as TableRowBlockObjectResponse[];
 
       return (
-        <table className="my-6 table-auto border-collapse border border-border">
+        <table className="my-6 table-auto border-collapse border border-contrast-300">
           {childrenBlock.map((tableRowBlock, row_idx) => (
             <tr>
               {tableRowBlock.table_row.cells.map((col, col_idx) =>
@@ -112,11 +112,11 @@ export const BlockRenderer = async ({ block }: { block: BlockObject }) => {
                  */
                 (row_idx === 0 && has_column_header) ||
                 (col_idx === 0 && has_row_header) ? (
-                  <th className="border border-border p-2 pr-6 bg-back-em text-left">
+                  <th className="border border-contrast-300 p-2 pr-6 bg-contrast-100-em text-left">
                     <RichText texts={col} />
                   </th>
                 ) : (
-                  <td className="border border-border p-2 pr-6">
+                  <td className="border border-contrast-300 p-2 pr-6">
                     <RichText texts={col} />
                   </td>
                 ),

--- a/notion/component/RichText.tsx
+++ b/notion/component/RichText.tsx
@@ -22,14 +22,16 @@ export const RichText = ({ texts }: { texts: RichTextItemResponse[] }) => {
       );
 
       if (bold)
-        element = <strong className="font-bold text-txt-700">{element}</strong>;
+        element = (
+          <strong className="font-bold text-contrast-700">{element}</strong>
+        );
       if (italic) element = <i>{element}</i>;
       if (strikethrough)
         element = <span className="line-through">{element}</span>;
       if (underline) element = <span>{element}</span>;
       if (code)
         element = (
-          <code className="inline-block px-1.5 mx-0.5 bg-back-em rounded-md text-txt-700">
+          <code className="inline-block px-1.5 mx-0.5 bg-contrast-100-em rounded-md text-contrast-700">
             {element}
           </code>
         );
@@ -37,7 +39,7 @@ export const RichText = ({ texts }: { texts: RichTextItemResponse[] }) => {
         element = (
           <Link
             href={href}
-            className="text-txt-300 underline underline-offset-4 hover:text-txt-500"
+            className="text-contrast-500 underline underline-offset-4 hover:text-contrast-600"
           >
             {element}
           </Link>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -15,14 +15,14 @@ const config: Config = {
         arita: ["var(--arita)"],
       },
       colors: {
-        txt: {
-          300: "rgba(var(--color-text-week), <alpha-value>)",
-          500: "rgba(var(--color-text), <alpha-value>)",
-          700: "rgba(var(--color-text-em), <alpha-value>)",
+        contrast: {
+          100: "rgba(var(--color-contrast-100), <alpha-value>)",
+          200: "rgba(var(--color-contrast-200), <alpha-value>)",
+          300: "rgba(var(--color-contrast-300), <alpha-value>)",
+          500: "rgba(var(--color-contrast-500), <alpha-value>)",
+          600: "rgba(var(--color-contrast-600), <alpha-value>)",
+          700: "rgba(var(--color-contrast-700), <alpha-value>)",
         },
-        border: "rgba(var(--color-border), <alpha-value>)",
-        back: "rgba(var(--color-bg), <alpha-value>)",
-        "back-em": "rgba(var(--color-bg-em), <alpha-value>)",
       },
     },
   },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -20,6 +20,7 @@ const config: Config = {
           500: "rgba(var(--color-text), <alpha-value>)",
           700: "rgba(var(--color-text-em), <alpha-value>)",
         },
+        border: "rgba(var(--color-border), <alpha-value>)",
         back: "rgba(var(--color-bg), <alpha-value>)",
         "back-em": "rgba(var(--color-bg-em), <alpha-value>)",
       },


### PR DESCRIPTION
### 색상 관련 변경 내용.
* 기존 색상 네이밍은 많이 쓰일 것 같은 요소 이름으로 했었음. (라이트모드, 다크모드에 따라 색상이 달라져서 색상으로 이름 지을 수 없었음.) **→** 그러나 요소 이름으로 짓긴 애매했고, 다른 이름을 생각한 끝에 특정 모드 색상과 대비된 정도라는 의미의 contrast를 사용함. (primary 도 생각했으나... primary의 degree가 6개나 되는게 좀 이상했음.)

* 경계선 전용 색상을 하나 더 추가함.