### PR TITLE
build: next.config.js 수정

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
+  experimental: {
+    missingSuspenseWithCSRBailout: false,
+  },
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
### 빌드 에러 수정

nextJS 14들어오면서 useSearchParams에 Suspense 달아두었음.
이건 좀 오버 엔지니어링이다 싶었는데 마침 이걸 끄는 옵션이 제공되었음. 그래서 해당 옵션을 사용해서 에러를 회피함.